### PR TITLE
Small feature: Service Matcher on Embed.ly Client

### DIFF
--- a/embedly/client.py
+++ b/embedly/client.py
@@ -63,25 +63,12 @@ class Embedly(object):
 
         return self.services
 
-    def service_matcher(self):
-        """
-        Generate a really big regular expression that we can use to determine if a URL is serviced by embedly or not.
-        Returns a compiled regular expression.
-        """
-        if self.service_re is not None:
-            return self.service_re
-
-        services            = self.get_services()
-        service_expressions = list(itertools.chain.from_iterable([service['regex'] for service in services]))
-        self.service_re     = re.compile('|'.join(service_expressions), re.I)
-
-        return self.service_re
-
     def url_is_serviced(self, url):
         """
         If a URL is serviced by Embed.ly, return True. Otherwise return False.
         """
-        return self.service_matcher().match(url) is not None
+        services = self.get_services()
+        return self._regex.match(url) is not None
 
     @property
     def regex(self):


### PR DESCRIPTION
Added a service matcher to the python client - allows you to determine if a URL is serviced by embed.ly or not. I think this is a [similar approach to what reddit uses](https://github.com/reddit/reddit/blob/b15470271c2230e429e8edc6ad81aec04f2d07c0/r2/r2/lib/scraper.py), except theirs is hardcoded.

In my own implementation I've also added a caching layer to get_services, which I think will be pretty important for speed, but isn't very implementation-agnostic just yet.

Not sure if this uses the same sort of internal lingo you guys might use at embed.ly - feel free to edit.
