### PR TITLE
Update installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Install with `Pip <http://www.pip-installer.org>`_ (recommended)::
 
 Or setuptools::
 
-  git clone git@github.com:embedly/embedly-python
+  git clone git://github.com/embedly/embedly-python.git
   sudo python setup.py
 
 


### PR DESCRIPTION
The instructions currently recommend using `sudo python setup.py`, which has been all but obsoleted by virtualenv+pip. This little patch fixes that.
