### PR TITLE
a suggestion more than a pull request

### DIFF
--- a/embedly/client.py
+++ b/embedly/client.py
@@ -66,7 +66,7 @@ class Embedly(object):
 
         if resp['status'] == '200':
             resp_data = json.loads(content)
-            if self.cache_services_data :
+            if self.cache_services_data is not None:
                 self.cache_services_data = resp_data
 
             self.set_services(resp_data)


### PR DESCRIPTION
not sure you'd be open to this, so I didn't put much time into it...

I wanted to be able to cache the embedly 'services' data:
- I don't want to make a blocking request on every appserver initialization or object instance
- I don't want a user-generated action to require multiple API calls

in order to handle this, the simplest way i thought of was to:
- split `get_services` into 
  -- `get_services` pulls the API data
  -- `set_services` actually does the setting & regex compiling
- add a `cache_services_data` argument to initialization
  -- if set to True -- or previously set during a get_ call -- will store the raw response data text

with these changes you can pull out the API info from client.cache_services_data and cache it, then create new objects with the same data by calling client2.set_services()
