### PR TITLE
Properly handle non-200 responses on multi-url requests

### DIFF
--- a/embedly/client.py
+++ b/embedly/client.py
@@ -136,6 +136,10 @@ class Embedly(object):
 
             if kwargs.get('raw', False):
                 data['raw'] = content
+        elif multi:
+            data = [{'type': 'error',
+                     'error': True,
+                     'error_code': int(resp['status'])}] * len(url_or_urls)
         else:
             data = {'type': 'error',
                     'error': True,


### PR DESCRIPTION
Currently, multi-url requests throw a `ValueError` when constructing the return list if the api requests returns anything other than a 200 response. The error happens specifically in this code:
```
return map(lambda url, data: Url(data, method, url),
                        url_or_urls, data)
```

When the status code isn't `200` (and it's a multi-url request), the `data` value is assigned to a dictionary (as opposed the list/json array you'd expect from a `200` response). When passed to `map(lambda url, data: Url(data, method, url), url_or_urls, data)`, `map` iterates through `data` and `url_or_urls` in parallel. Under successful `200` responses, `data` and `url_or_urls` are lists of equal length. In any other case, `data` is a dictionary, so `map` iterates through the _keys_ of the dictionary. This causes exceptions because the `data` arg passed to the lambda func is now a string, not a dict.

This fix works by simply copying the error data `len(url_or_urls)` times in a list, mimicking the list format expected in the downstream `map` function.