### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ The client object now has a bunch of different methods that you can use.
     >>> client.objectify('http://vimeo.com/18150336')
     <embedly.models.Url at 0x10223d950>
 
-The above functions all take the same arguements, a URL or a list of URLs and
+The above functions all take the same arguments, a URL or a list of URLs and
 keyword arguments that correspond to Embedly's `query arguments
 <http://embed.ly/docs/endpoints/arguments>`_. Here is an example::
 

--- a/embedly/models.py
+++ b/embedly/models.py
@@ -7,7 +7,7 @@ class Url(IterableUserDict, object):
     """
     A dictionary with two additional attributes for the method and url.
     UserDict provides a dictionary interface along with the regular
-    dictionary accsesible via the `data` attribute.
+    dictionary accessible via the `data` attribute.
 
     """
     def __init__(self, data=None, method=None, original_url=None, **kwargs):


### PR DESCRIPTION
There are small typos in:
- README.rst
- embedly/models.py

Fixes:
- Should read `arguments` rather than `arguements`.
- Should read `accessible` rather than `accsesible`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md