### PR TITLE
fix tuple/list error to resolve issue with newer setuptools

### DIFF
--- a/embedly/__init__.py
+++ b/embedly/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import absolute_import
 from .client import Embedly
 
-__version__ = '0.5.0'
+__version__ = '0.5.0.post0'

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     test_suite="embedly.tests",
     zip_safe=True,
     use_2to3=True,
-    classifiers=(
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Natural Language :: English',
@@ -54,5 +54,5 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
-    )
+    ]
 )


### PR DESCRIPTION
This should resolve any issues with modern setuptools where a list is required for classifiers.